### PR TITLE
refactor: Parsed lilybit to hundreds and millions

### DIFF
--- a/apps/info-dashboard/src/app/leaderboard/page.tsx
+++ b/apps/info-dashboard/src/app/leaderboard/page.tsx
@@ -180,12 +180,10 @@ export default function Leaderboard() {
 											leaderboardData
 												? leaderboardData.reduce(
 														(total, node) =>
-															+node.Points +
-															total,
-														0
+															+node.Points +total, 0
 												  )
 												: 0
-										)}
+										).toLocaleString()}
 									</span>
 								</div>
 								{/* Todo add api week total Lilybit_rewards earned */}

--- a/apps/info-dashboard/src/lib/fetchers/leaderboard.ts
+++ b/apps/info-dashboard/src/lib/fetchers/leaderboard.ts
@@ -65,7 +65,7 @@ export function toTableData({
 						  } as const);
 				return result;
 			})(),
-			"Reward Points": Math.round(+Points * 100) / 100,
+			"Reward Points": (Math.round(+Points * 100) / 100).toLocaleString(),
 
 			Status: (() => {
 				const online = nodesData.find(


### PR DESCRIPTION
### Review Type Requested (choose one):

- [x] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary

Parse the lilybit total and reward, ie 1400 to 1,400, 14000000 to 14,000,000

### Task/Issue reference

Closes: #92 

### Details (optional)

I also included the Lilybit rewards on the leaderboard table

![image](https://github.com/user-attachments/assets/aa8dadac-d14b-464a-8a54-eac238e6d589)
