### PR TITLE
chore: revive rp's online status and connection duration in leaderboard

### DIFF
--- a/apps/info-dashboard/src/app/leaderboard/page.tsx
+++ b/apps/info-dashboard/src/app/leaderboard/page.tsx
@@ -180,7 +180,9 @@ export default function Leaderboard() {
 											leaderboardData
 												? leaderboardData.reduce(
 														(total, node) =>
-															+node.Points +total, 0
+															+node.Points +
+															total,
+														0
 												  )
 												: 0
 										).toLocaleString()}
@@ -543,7 +545,7 @@ export default function Leaderboard() {
 															}
 														/>
 													</td>
-													{/* <td>
+													<td>
 														<TableLeadText
 															title={
 																<Badge
@@ -576,7 +578,7 @@ export default function Leaderboard() {
 																]
 															}
 														/>
-													</td> */}
+													</td>
 													<td>
 														<TableLeadText
 															title={

--- a/apps/info-dashboard/src/lib/fetchers/leaderboard.ts
+++ b/apps/info-dashboard/src/lib/fetchers/leaderboard.ts
@@ -152,8 +152,7 @@ export function getHeaderData() {
 					m.leaderboard_header_tooltip_description_reward_points(),
 			},
 		},
-
-		/* {
+		{
 			name: "Status",
 			translation: m.leaderboard_header_titles_status(),
 			tooltip: {
@@ -169,7 +168,7 @@ export function getHeaderData() {
 				description:
 					m.node_status_header_tooltip_description_connected_since(),
 			},
-		}, */
+		},
 		{
 			name: "Share",
 			translation: m.leaderboard_header_titles_share(),


### PR DESCRIPTION
### Review Type Requested (choose one):

- [ ] **Glance** - superficial check (from domain experts)
- [ ] **Logic** - thorough check (from everybody doing review)

### Summary

Provide a one line summary and link to any relevant references
return online and connection duration in leaderboard table
### Task/Issue reference
 https://github.com/Lilypad-Tech/web-ui/issues/76
Closes: add_link_here

### Details (optional)

Add any additional details that might help Code Reviewers digest this PR

### How to test this code? (optional)

### Anything else? (optional)
